### PR TITLE
Typo in README: "Acknowledgement"

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,6 @@ If you find OpenIns3D and this codebase useful for your research, please cite ou
 
 ```
 
-# Acknowlegement
+# Acknowledgement
 
 The mask proposal model is modified from [Mask3D](https://jonasschult.github.io/Mask3D/), and we heavily used the [easy setup](https://github.com/cvg/Mask3D) version of it for MPM. Thanks again for the great work! 🙌 We also drew inspiration from [LAR](https://github.com/eslambakr/LAR-Look-Around-and-Refer) and [ContrastiveSceneContexts](https://github.com/facebookresearch/ContrastiveSceneContexts) when developing the code. 🚀


### PR DESCRIPTION
Corrected the spelling of "Acknowlegement" to "Acknowledgement" in the README file.